### PR TITLE
Output to results pane

### DIFF
--- a/arduino-cli.py
+++ b/arduino-cli.py
@@ -4,13 +4,12 @@ def get_setting(name):
     settings = sublime.load_settings('arduino-cli.sublime-settings')
     return sublime.active_window().active_view().settings().get(name, settings.get(name))
 
-class ArduinoCommand(sublime_plugin.WindowCommand):
+class ArduinocliCommand(sublime_plugin.WindowCommand):
 
     def run(self, **kwargs):
         sublime.set_timeout_async(lambda: self.go(kwargs), 0)
 
     def go(self, options):
-        ino = options["working_dir"]
 
         args = [get_setting('path')]
 
@@ -26,18 +25,9 @@ class ArduinoCommand(sublime_plugin.WindowCommand):
         if sketchbook_path:
             args += ["--pref", "sketchbook.path={}".format(sketchbook_path)]
 
-        args += ["--{}".format(self.action), ino]
+        args += options['cmd']
 
-        print(args)
-        try:
-            a = subprocess.check_output(args, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as e:
-            print(e.output)
-        else:
-            print(a)
+        options['cmd'] = args
+        options['shell'] = True
 
-class ArduinoverifyCommand(ArduinoCommand):
-    action = "verify"
-
-class ArduinouploadCommand(ArduinoCommand):
-    action = "upload"
+        self.window.run_command("exec", options)

--- a/arduino-cli.py
+++ b/arduino-cli.py
@@ -28,6 +28,5 @@ class ArduinocliCommand(sublime_plugin.WindowCommand):
         args += options['cmd']
 
         options['cmd'] = args
-        options['shell'] = True
 
         self.window.run_command("exec", options)

--- a/arduino-cli.sublime-build
+++ b/arduino-cli.sublime-build
@@ -1,7 +1,6 @@
 {
     "target": "arduinocli",
     "cmd": ["--verify", "$file"],
-    "shell": true,
 
     "selector": "source.arduino",
 

--- a/arduino-cli.sublime-build
+++ b/arduino-cli.sublime-build
@@ -1,6 +1,7 @@
 {
     "target": "arduinocli",
     "cmd": ["--verify", "$file"],
+    "shell": true,
 
     "selector": "source.arduino",
 

--- a/arduino-cli.sublime-build
+++ b/arduino-cli.sublime-build
@@ -1,22 +1,21 @@
 {
-   "_comment": "using targets instead of cmd for two reasons. One PATH is difficult in OSX gui",
-   "_comment": "though not at all from python. Two I dont know a way to get user settings from here",
-    "target": "arduinoupload",
-
-    "_comment": "it seems only working_dir and cmd vars are expanded so smuggle file through working_dir",
-    "working_dir": "${file}",
+    "target": "arduinocli",
+    "cmd": ["--verify", "$file"],
 
     "selector": "source.arduino",
-    
-    "_comment": "doesnt seem to work yet. might be impossible as arduino doesnt return full path name of file",
+
+    // doesnt seem to work yet. might be impossible as arduino doesnt return full path name of file
     "file_regex": "b'(\\w*.\\w*):(\\d*):(\\d*):(.*)",
 
     "variants": [
+
         { "name": "just build",
-          "target": "arduinoverify",
+          "cmd": ["--verify", "$file"],
         },
+
         { "name": "build and upload",
-          "target": "arduinoupload",
-        }
+          "cmd": ["--upload", "$file"],
+        },
+
     ]
 }


### PR DESCRIPTION
I wasn't really using arduino-cli because it wasn't outputting the build info to the results pane... So I refactored it a bit to do that.

It now calls the exec command that simple build systems use, but ArduinocliCommand first takes in the build system options, gets the arduino executable from settings as before, and then calls exec once the options have been correctly configured.

This means it looks like a normal build system when it outputs
