### PR TITLE
Build from any file (not just .ino file), wildcards in compiler path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Command + Shift + B (or Ctrl+Shift+B) lets you select to just build.
 SETTINGS
 --------
 Settings include:
- * path - The path to the Arduino executable, may include wildcards. eg /Applications/Arduino.app/Contents/MacOS/Arduino or "C:\Program Files&ast;\Arduino\arduino-debug.exe"
+ * path - The path to the Arduino executable, may include wildcards. eg /Applications/Arduino.app/Contents/MacOS/Arduino or "C:\Program Files&ast;\Arduino\arduino&#95;debug.exe"
  * board - (optional) The package:arch:board. See the [Arduino CLI docs](https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc). eg arduino:avr:uno
  * port - (optional) The serialport to upload with. eg /dev/tty.usbmodem1411
  * sketchbook.path - (optional) The directory to look for additonal libraries and architectures in. eg /Users/jacobrosenthal/Documents/firmware-pinoccio/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ select to just build.
 SETTINGS
 --------
 Settings include:
- * path - The path to the Arduino executable. eg /Applications/Arduino.app/Contents/MacOS/Arduino
+ * path - The path to the Arduino executable, may include wildcards. eg /Applications/Arduino.app/Contents/MacOS/Arduino or "C:\Program Files&ast;\Arduino\arduino-debug.exe"
  * board - (optional) The package:arch:board. See the [Arduino CLI docs](https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc). eg arduino:avr:uno
  * port - (optional) The serialport to upload with. eg /dev/tty.usbmodem1411
  * sketchbook.path - (optional) The directory to look for additonal libraries and architectures in. eg /Users/jacobrosenthal/Documents/firmware-pinoccio/

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Use [Package Control](https://packagecontrol.io/installation) to install. Within
 
 USE
 ---
-While viewing a .ino file, use Command + b builds and upload to your board. Command + Shift + B lets you 
-select to just build.
+While viewing a .ino/.cpp/.h file in an Arduino project directory, use Command + B (or Ctrl+B) to build and upload the sketch to your board.
+Command + Shift + B (or Ctrl+Shift+B) lets you select to just build.
 
 SETTINGS
 --------

--- a/arduino-cli (Windows).sublime-settings
+++ b/arduino-cli (Windows).sublime-settings
@@ -1,3 +1,3 @@
 {
-	"path" : "C:\\Program Files (x86)\\Arduino\\arduino_debug.exe"
+	"path" : "C:\\Program Files*\\Arduino\\arduino_debug.exe"
 }

--- a/arduino-cli.py
+++ b/arduino-cli.py
@@ -1,4 +1,9 @@
 import subprocess, sublime, sublime_plugin
+import os
+import glob
+
+SKETCH_FILE_EXTENSTION = ".ino"
+SKETCH_FILE_PATTERN = "*.ino"
 
 def get_setting(name):
     settings = sublime.load_settings('arduino-cli.sublime-settings')
@@ -9,6 +14,28 @@ class ArduinocliCommand(sublime_plugin.WindowCommand):
     def run(self, **kwargs):
         sublime.set_timeout_async(lambda: self.go(kwargs), 0)
 
+    def _find_ino_file(self, filename):
+        project_dir = os.path.dirname(filename)
+        
+        # The .ino file is probably in the current directory,
+        # but maybe it's in the parent directory
+        for d in [".", ".."]:
+            ino_files = glob.glob(os.path.join(project_dir, d, SKETCH_FILE_PATTERN))
+            if len(ino_files) == 1:
+                return os.path.normpath(ino_files[0])
+        
+        raise ValueError("There should be exactly one .ino file in the project directory")
+        
+    def _get_filename(self):
+        return sublime.active_window().active_view().file_name()
+        
+    def _set_ino_file(self, cmd):
+        filename = self._get_filename()
+        cmd[cmd.index(filename)] = self._find_ino_file(filename)
+        
+    def _is_ino_file(self):
+        return self._get_filename().endswith(SKETCH_FILE_EXTENSTION)
+        
     def go(self, options):
 
         args = [get_setting('path')]
@@ -25,7 +52,12 @@ class ArduinocliCommand(sublime_plugin.WindowCommand):
         if sketchbook_path:
             args += ["--pref", "sketchbook.path={}".format(sketchbook_path)]
 
-        args += options['cmd']
+        cmd = options['cmd']
+        
+        if not self._is_ino_file():
+            self._set_ino_file(cmd)
+        
+        args += cmd
 
         options['cmd'] = args
 

--- a/arduino-cli.py
+++ b/arduino-cli.py
@@ -1,4 +1,5 @@
 import subprocess, sublime, sublime_plugin
+import glob
 
 def get_setting(name):
     settings = sublime.load_settings('arduino-cli.sublime-settings')
@@ -11,7 +12,13 @@ class ArduinocliCommand(sublime_plugin.WindowCommand):
 
     def go(self, options):
 
-        args = [get_setting('path')]
+        compiler_path = get_setting('path')
+        if "?" in compiler_path or "*" in compiler_path:
+            compiler_paths = glob.glob(compiler_path)
+            assert len(compiler_paths) == 1, "There should be only one compiler matching the given path (See arduino-cli (Platform).sublime-settings file"
+            compiler_path = compiler_paths[0]
+
+        args = [compiler_path]
 
         board = get_setting('board')
         if board:


### PR DESCRIPTION
The point is to ease development when separating project to .cpp and .h files, and to support Windows systems that can have the compile installed in either "C:\Program Files\Arduino" or "C:\Program Files\Arduino (x86)" - that being solved by allowing wildcard in this path ("C:\Program Files*\Arduino").
Documentation updated as well.